### PR TITLE
zebra: check multipath before using recursively resolved blackhole nh

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2308,6 +2308,19 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 		nl_attr_nest_end(&req->n, nest);
 	}
 
+	/* Count overall nexthops so we can decide whether to use singlepath
+	 * or multipath case.
+	 */
+	nexthop_num = 0;
+	for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx), nexthop)) {
+		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+			continue;
+		if (!NEXTHOP_IS_ACTIVE(nexthop->flags))
+			continue;
+
+		nexthop_num++;
+	}
+
 	/*
 	 * Always install blackhole routes without using nexthops, because of
 	 * the following kernel problems:
@@ -2315,7 +2328,7 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 	 * 2. Blackhole kernel nexthops are deleted when loopback is down.
 	 */
 	nexthop = dplane_ctx_get_ng(ctx)->nexthop;
-	if (nexthop) {
+	if (nexthop && nexthop_num == 1) {
 		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 			nexthop = nexthop->resolved;
 
@@ -2370,19 +2383,6 @@ ssize_t netlink_route_multipath_msg_encode(int cmd, struct zebra_dplane_ctx *ctx
 		}
 
 		return NLMSG_ALIGN(req->n.nlmsg_len);
-	}
-
-	/* Count overall nexthops so we can decide whether to use singlepath
-	 * or multipath case.
-	 */
-	nexthop_num = 0;
-	for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx), nexthop)) {
-		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
-			continue;
-		if (!NEXTHOP_IS_ACTIVE(nexthop->flags))
-			continue;
-
-		nexthop_num++;
 	}
 
 	/* Singlepath case. */


### PR DESCRIPTION
In case a static route is resolving over multiple nexthops (multipath), if the first nexthop in the list is recursively resolving over a blackhole, zebra does not bother looking at other nexthops and sends a netlink update to the kernel marking the route as a blackhole. This results in complete traffic blackholing even in a multipath setup.

If number of nexthops > 1, do not bother checking for recursively resolved blackhole nexthop. Let zebra's multipath handling take over.